### PR TITLE
Fix kais install scripts on latest containerd env

### DIFF
--- a/beta/Containerd-v2-02-k8s.sh
+++ b/beta/Containerd-v2-02-k8s.sh
@@ -38,6 +38,7 @@ sudo apt-get update
 
 # Essential Tweaks
 sudo swapoff -a
+sudo ln -sf /dev/null /etc/systemd/system-generators/systemd-gpt-auto-generator
 cat << EOF | sudo tee /etc/modules-load.d/k8s.conf
 overlay
 br_netfilter
@@ -59,11 +60,11 @@ sudo kubeadm init --service-cidr=10.96.0.0/12 --pod-network-cidr=10.244.0.0/16 -
 
 mkdir -p $HOME/.kube
 # Copy the kubeconfig file to the .kube directory
-sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
+sudo cp -f /etc/kubernetes/admin.conf $HOME/.kube/config
 # Change ownership of the kubeconfig file to your user
 sudo chown $(id -u):$(id -g) $HOME/.kube/config
 
-kubectl taint node --all node-role.kubernetes.io/control-plane:NoSchedule-
+kubectl taint node --all node-role.kubernetes.io/control-plane:NoSchedule- || true
 
 # set up autocomplete in bash into the current shell, bash-completion package should be installed first.
 source <(kubectl completion bash) 

--- a/latest/Rocky_Linux-K8s_latest-containerd-flannel.sh
+++ b/latest/Rocky_Linux-K8s_latest-containerd-flannel.sh
@@ -142,6 +142,8 @@ do_k8s_tweaks(){
     sudo swapoff -a
     # sudo sed -i '/swap/s/^/#/' /etc/fstab
     sudo sed -i '/ swap / s/^\(.*\)$/#\1/g' /etc/fstab
+    sudo ln -sf /dev/null /etc/systemd/system-generators/systemd-gpt-auto-generator
+    _info "Link /dev/null to /etc/systemd/system-generators/systemd-gpt-auto-generator to avoid systemd auto generate swap service"
 cat << EOF | sudo tee /etc/modules-load.d/k8s.conf
 overlay
 br_netfilter
@@ -180,8 +182,8 @@ copy_kube_config(){
 remove_node_taint(){
 
     _info "Remove taint from the node"
-    kubectl taint nodes --all node-role.kubernetes.io/master-
-    kubectl taint nodes --all node-role.kubernetes.io/control-plane-
+    kubectl taint nodes --all node-role.kubernetes.io/master- || true
+    kubectl taint nodes --all node-role.kubernetes.io/control-plane- || true
 
 }
 
@@ -223,7 +225,9 @@ main(){
     do_k8s_tweaks
     install_k8s_yum_packages
     sudo systemctl enable --now kubelet
-    sudo kubeadm init --service-cidr=10.96.0.0/12 --pod-network-cidr=10.244.0.0/16 --image-repository=registry.k8s.io --v=6
+    if [ ! -f /etc/kubernetes/admin.conf ]; then
+        sudo kubeadm init --service-cidr=10.96.0.0/12 --pod-network-cidr=10.244.0.0/16 --image-repository=registry.k8s.io --v=6
+    fi
     copy_kube_config
     remove_node_taint
     ## Apply CNI

--- a/latest/Rocky_Linux-K8s_latest-containerd-flannel.sh
+++ b/latest/Rocky_Linux-K8s_latest-containerd-flannel.sh
@@ -142,8 +142,6 @@ do_k8s_tweaks(){
     sudo swapoff -a
     # sudo sed -i '/swap/s/^/#/' /etc/fstab
     sudo sed -i '/ swap / s/^\(.*\)$/#\1/g' /etc/fstab
-    sudo ln -sf /dev/null /etc/systemd/system-generators/systemd-gpt-auto-generator
-    _info "Link /dev/null to /etc/systemd/system-generators/systemd-gpt-auto-generator to avoid systemd auto generate swap service"
 cat << EOF | sudo tee /etc/modules-load.d/k8s.conf
 overlay
 br_netfilter

--- a/latest/Ubuntu-K8s_latest-containerd-flannel.sh
+++ b/latest/Ubuntu-K8s_latest-containerd-flannel.sh
@@ -25,7 +25,7 @@ K8S_WORKER_NODE_PACKAGE=(
 
 
 _mk_tmp_dir(){
-    mkdir "${TEMP_DIR}"
+    mkdir -p "${TEMP_DIR}"
 }
 
 
@@ -49,36 +49,30 @@ _error(){
 _get_latest_docker_version(){
 
     local request_result
-    request_result=$(curl https://download.docker.com/linux/${OS_ID}/dists/${OS_CODE_NAME}/pool/stable/${CPU_ARCH}/)
+    # Ensure OS_ID is lowercase for the URL
+    local target_url="https://download.docker.com/linux/${OS_ID}/dists/${OS_CODE_NAME}/pool/stable/${CPU_ARCH}/"
+
+    _info "Fetching versions from: ${target_url}"
+    request_result=$(curl -sL "${target_url}")
 
     for package in docker-ce docker-ce-cli containerd.io
     do
+        # This regex captures the full version string including metadata (~ubuntu...)
+        # It looks for: package_ [capture everything] _cpu_arch.deb
+        package_version=$(echo "${request_result}" | grep -oP "${package}_\K[^_]+(?=_${CPU_ARCH}\.deb)" | sort -V | tail -n 1)
 
-        package_version=$(echo "${request_result}" | grep "${package}_" | sed -n "s/.*${package}_\([^_]*\)_${CPU_ARCH}\.deb.*/\1/p" | sort -V | tail -n 1 | cut -d'~' -f1)
+        if [ -z "${package_version}" ]; then
+            _error "Could not find version for ${package}"
+            continue
+        fi
 
-    case "${package}" in
-
-        docker-ce)
-        dockerce_version="${package_version}"
-        ;;
-
-        docker-ce-cli)
-        dockercecli_version="${package_version}"
-        ;;
-
-        containerd.io)
-        containerd_version="${package_version}"
-        ;;
-
-        *)
-        _error "Unexpected package."
-        ;;
-    esac
-
+        case "${package}" in
+            docker-ce)     dockerce_version="${package_version}" ;;
+            docker-ce-cli) dockercecli_version="${package_version}" ;;
+            containerd.io) containerd_version="${package_version}" ;;
+        esac
     done
-
 }
-
 
 
 check_command_available(){
@@ -223,34 +217,47 @@ mark_apt_packages(){
 install_docker_runtime(){
 
     _info "Checking if iptables is installed"
-    if check_command_available "iptables"
-    then
+    if check_command_available "iptables"; then
         _info "iptables is installed."
     else
-        _info "iptables is NOT installed, installing it cuz docker-ce needs it."
+        _info "iptables is NOT installed, installing it because docker-ce needs it."
         install_apt_packages iptables
     fi
 
+    local docker_deb_dir="${TEMP_DIR}/docker_debs"
     base_url="https://download.docker.com/linux/${OS_ID}/dists/${OS_CODE_NAME}/pool/stable/${CPU_ARCH}"
 
-    _info "Download and installing debs from docker"
-    for DEB in ${DOCKER_DEB[@]}
-    do
-        _info "Download and installing ${DEB}"
-        curl -s --create-dirs -o "${TEMP_DIR}/docker_debs/${DEB}" "${base_url}/$DEB"
-        sudo dpkg -i "${TEMP_DIR}/docker_debs/${DEB}"
+    # Step 1: Download all required debs first
+    _info "Downloading debs from Docker repository..."
+    for DEB in "${DOCKER_DEB[@]}"; do
+        _info "Fetching: ${DEB}"
+        curl -s --create-dirs -L -o "${docker_deb_dir}/${DEB}" "${base_url}/${DEB}"
     done
 
-    # containerd
+    # Step 2: Atomic installation
+    # Passing all files to dpkg at once lets it resolve dependencies (CLI vs Engine) internally.
+    _info "Installing Docker packages via dpkg..."
+    sudo dpkg -i "${docker_deb_dir}/"*.deb || {
+        _error "dpkg encountered issues; attempting to fix dependencies with apt..."
+        sudo apt-get install -f -y
+    }
+
+    # Step 3: Containerd configuration (Crucial for K8s)
     _info "Setting up containerd"
     sudo mkdir -p /etc/containerd
-    sudo containerd config default | sudo tee /etc/containerd/config.toml
+    # Generate default config and enable SystemdCgroup
+    sudo containerd config default | sudo tee /etc/containerd/config.toml > /dev/null
     sudo sed -i "s/SystemdCgroup = false/SystemdCgroup = true/g" /etc/containerd/config.toml
-    grep SystemdCgroup /etc/containerd/config.toml
+
+    _info "Verifying SystemdCgroup setting:"
+    grep "SystemdCgroup" /etc/containerd/config.toml
+
     sudo systemctl restart containerd
 
-_info "Changing docker cgroup driver to systemd"
-cat <<EOF | sudo tee /etc/docker/daemon.json
+    # Step 4: Docker Engine configuration
+    _info "Changing docker cgroup driver to systemd"
+    sudo mkdir -p /etc/docker
+    cat <<EOF | sudo tee /etc/docker/daemon.json
 {
   "exec-opts": ["native.cgroupdriver=systemd"],
   "log-driver": "json-file",
@@ -261,15 +268,21 @@ cat <<EOF | sudo tee /etc/docker/daemon.json
 }
 EOF
 
+    # Step 5: Post-install setup
     sudo mkdir -p /etc/systemd/system/docker.service.d
+
     _info "Adding current user to docker group"
-    sudo usermod -aG docker $(logname)
-    _info "Restarting docker"
+    # Using $USER as a fallback if logname fails in certain shell environments
+    CURRENT_USER=$(logname 2>/dev/null || echo $USER)
+    sudo usermod -aG docker "$CURRENT_USER"
+
+    _info "Reloading systemd and restarting Docker"
     sudo systemctl daemon-reload
     sudo systemctl enable docker
     sudo systemctl restart docker
-    systemctl status --no-pager docker
 
+    # Final health check
+    systemctl status --no-pager docker | grep "Active:"
 }
 
 
@@ -290,9 +303,8 @@ do_k8s_tweaks(){
     _info "Disabling off swap"
     sudo swapoff -a
     sudo sed -i '/swap/s/^/#/' /etc/fstab
-    [ ! -d "/etc/systemd/system-generators" ] && sudo mkdir -p "/etc/systemd/system-generators" && _info "Created path: /etc/systemd/system-generators"
+    sudo ln -sf /dev/null /etc/systemd/system-generators/systemd-gpt-auto-generator
     _info "Link /dev/null to /etc/systemd/system-generators/systemd-gpt-auto-generator to avoid systemd auto generate swap service"
-    sudo ln -s /dev/null /etc/systemd/system-generators/systemd-gpt-auto-generator
 
 cat << EOF | sudo tee /etc/modules-load.d/k8s.conf
 overlay
@@ -316,7 +328,7 @@ copy_kube_config(){
 
     _info "Copy kube config to home directory"
     mkdir -p $HOME/.kube
-    sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
+    sudo cp -f /etc/kubernetes/admin.conf $HOME/.kube/config
     sudo chown $(id -u):$(id -g) $HOME/.kube/config
 
 }
@@ -325,8 +337,8 @@ copy_kube_config(){
 remove_node_taint(){
 
     _info "Remove taint from the node"
-    kubectl taint nodes --all node-role.kubernetes.io/master-
-    kubectl taint nodes --all node-role.kubernetes.io/control-plane-
+    kubectl taint nodes --all node-role.kubernetes.io/master- || true
+    kubectl taint nodes --all node-role.kubernetes.io/control-plane- || true
 
 }
 
@@ -351,6 +363,8 @@ get_flannel_latest_version(){
 
 main(){
 
+    trap _clean_up EXIT
+
     # Gather the init info for installation
     get_os_info
     get_k8s_relaese_version
@@ -366,8 +380,8 @@ main(){
     fi
     DOCKER_DEB=(
         "containerd.io_${containerd_version}_${CPU_ARCH}.deb"
-        "docker-ce_${dockerce_version}~ubuntu.${OS_RELESE_VER}~${OS_CODE_NAME}_${CPU_ARCH}.deb"
-        "docker-ce-cli_${dockercecli_version}~ubuntu.${OS_RELESE_VER}~${OS_CODE_NAME}_${CPU_ARCH}.deb"
+        "docker-ce_${dockerce_version}_${CPU_ARCH}.deb"
+        "docker-ce-cli_${dockercecli_version}_${CPU_ARCH}.deb"
     )
     install_docker_runtime
     # Install Kubernetes
@@ -376,7 +390,9 @@ main(){
     install_apt_packages "${K8S_CONTROL_PLANE_PACKAGE[@]}"
     mark_apt_packages "${K8S_CONTROL_PLANE_PACKAGE[@]}"
     sudo systemctl enable --now kubelet
-    sudo kubeadm init --service-cidr=10.96.0.0/12 --pod-network-cidr=10.244.0.0/16 --image-repository=registry.k8s.io --v=6
+    if [ ! -f /etc/kubernetes/admin.conf ]; then
+        sudo kubeadm init --service-cidr=10.96.0.0/12 --pod-network-cidr=10.244.0.0/16 --image-repository=registry.k8s.io --v=6
+    fi
     copy_kube_config
     remove_node_taint
     ## Apply CNI

--- a/latest/Unified-K8s_latest-containerd-flannel.sh
+++ b/latest/Unified-K8s_latest-containerd-flannel.sh
@@ -207,9 +207,8 @@ do_k8s_tweaks(){
     _info "Disabling off swap"
     sudo swapoff -a
     sudo sed -i '/swap/s/^/#/' /etc/fstab
-    [ ! -d "/etc/systemd/system-generators" ] && sudo mkdir -p "/etc/systemd/system-generators" && _info "Created path: /etc/systemd/system-generators"
+    sudo ln -sf /dev/null /etc/systemd/system-generators/systemd-gpt-auto-generator
     _info "Link /dev/null to /etc/systemd/system-generators/systemd-gpt-auto-generator to avoid systemd auto generate swap service"
-    sudo ln -s /dev/null /etc/systemd/system-generators/systemd-gpt-auto-generator
 
 cat << EOF | sudo tee /etc/modules-load.d/k8s.conf
 overlay
@@ -242,8 +241,8 @@ copy_kube_config(){
 remove_node_taint(){
 
     _info "Remove taint from the node"
-    kubectl taint nodes --all node-role.kubernetes.io/master-
-    kubectl taint nodes --all node-role.kubernetes.io/control-plane-
+    kubectl taint nodes --all node-role.kubernetes.io/master- || true
+    kubectl taint nodes --all node-role.kubernetes.io/control-plane- || true
 
 }
 
@@ -318,7 +317,9 @@ main(){
     fi
 
     sudo systemctl enable --now kubelet
-    sudo kubeadm init --service-cidr=10.96.0.0/12 --pod-network-cidr=10.244.0.0/16 --image-repository=registry.k8s.io --v=6
+    if [ ! -f /etc/kubernetes/admin.conf ]; then
+        sudo kubeadm init --service-cidr=10.96.0.0/12 --pod-network-cidr=10.244.0.0/16 --image-repository=registry.k8s.io --v=6
+    fi
     copy_kube_config
     remove_node_taint
     kubectl apply -f https://github.com/flannel-io/flannel/releases/download/${FLANNEL_VERSION}/kube-flannel.yml

--- a/latest/Unified-K8s_latest-containerd-flannel.sh
+++ b/latest/Unified-K8s_latest-containerd-flannel.sh
@@ -207,8 +207,10 @@ do_k8s_tweaks(){
     _info "Disabling off swap"
     sudo swapoff -a
     sudo sed -i '/swap/s/^/#/' /etc/fstab
-    sudo ln -sf /dev/null /etc/systemd/system-generators/systemd-gpt-auto-generator
-    _info "Link /dev/null to /etc/systemd/system-generators/systemd-gpt-auto-generator to avoid systemd auto generate swap service"
+    if [ "$OS_FAMILY" == "debian" ]; then
+        sudo ln -sf /dev/null /etc/systemd/system-generators/systemd-gpt-auto-generator
+        _info "Link /dev/null to /etc/systemd/system-generators/systemd-gpt-auto-generator to avoid systemd auto generate swap service"
+    fi
 
 cat << EOF | sudo tee /etc/modules-load.d/k8s.conf
 overlay

--- a/legacy/Ubuntu2004-K8s_1_23-dockershim-calico.sh
+++ b/legacy/Ubuntu2004-K8s_1_23-dockershim-calico.sh
@@ -63,6 +63,7 @@ overlay
 br_netfilter
 EOF
 sudo swapoff -a
+sudo ln -sf /dev/null /etc/systemd/system-generators/systemd-gpt-auto-generator
 sudo sed -i '/ swap / s/^\(.*\)$/#\1/g' /etc/fstab
 sudo free -m
 source <(kubectl completion bash)
@@ -72,7 +73,7 @@ echo "source <(kubectl completion bash)" >> ~/.bashrc
 sudo kubeadm init --pod-network-cidr=192.168.0.0/16
 ## Copy Config
 mkdir -p $HOME/.kube
-sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
+sudo cp -f /etc/kubernetes/admin.conf $HOME/.kube/config
 sudo chown $(id -u):$(id -g) $HOME/.kube/config
 
 ### calico CNI
@@ -85,5 +86,5 @@ watch -n 1 kubectl get nodes
 watch kubectl get pods -n calico-system
 
 ## Taint(if needed)
-kubectl taint nodes --all node-role.kubernetes.io/master-
+kubectl taint nodes --all node-role.kubernetes.io/master- || true
 #kubectl taint nodes --all node-role.kubernetes.io/control-plane- node-role.kubernetes.io/master-

--- a/legacy/Ubuntu2004-K8s_1_23-dockershim-flannel.sh
+++ b/legacy/Ubuntu2004-K8s_1_23-dockershim-flannel.sh
@@ -62,6 +62,7 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo swapoff -a
+sudo ln -sf /dev/null /etc/systemd/system-generators/systemd-gpt-auto-generator
 
 # Disable swap
 sudo sed -e '/swap/ s/^#*/# /' -i /etc/fstab
@@ -86,7 +87,7 @@ sudo kubeadm init --service-cidr=10.96.0.0/12 --pod-network-cidr=10.244.0.0/16 -
 
 ## Copy Config
 mkdir -p $HOME/.kube
-sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
+sudo cp -f /etc/kubernetes/admin.conf $HOME/.kube/config
 sudo chown $(id -u):$(id -g) $HOME/.kube/config
 
 ## Flannel CNI
@@ -97,4 +98,4 @@ kubectl cluster-info
 watch -n 1 kubectl get nodes -o wide
 
 ## Taint(if needed)
-kubectl taint nodes --all node-role.kubernetes.io/master-
+kubectl taint nodes --all node-role.kubernetes.io/master- || true

--- a/legacy/Ubuntu2004-K8s_1_24-containerd-flannel.sh
+++ b/legacy/Ubuntu2004-K8s_1_24-containerd-flannel.sh
@@ -9,8 +9,9 @@ sudo apt update
 apt-cache madison kubeadm
 sudo apt-get install -y kubelet kubeadm kubectl
 
-sudo sed -ri 's/.*swap.*/#&/' /etc/fstab
 sudo swapoff -a
+sudo sed -i '/swap/s/^/#/' /etc/fstab
+sudo ln -sf /dev/null /etc/systemd/system-generators/systemd-gpt-auto-generator
 
 mkdir containerd && cd containerd
 
@@ -64,10 +65,10 @@ kubeadm config images pull --image-repository=registry.k8s.io --kubernetes-versi
 sudo kubeadm init --service-cidr=10.96.0.0/12 --pod-network-cidr=10.244.0.0/16 --image-repository=registry.k8s.io --v=6
 
 mkdir -p $HOME/.kube
-sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
+sudo cp -f /etc/kubernetes/admin.conf $HOME/.kube/config
 sudo chown $(id -u):$(id -g) $HOME/.kube/config
 
-kubectl taint nodes --all node-role.kubernetes.io/master-
-kubectl taint nodes --all node-role.kubernetes.io/control-plane-
+kubectl taint nodes --all node-role.kubernetes.io/master- || true
+kubectl taint nodes --all node-role.kubernetes.io/control-plane- || true
 kubectl apply -f https://github.com/flannel-io/flannel/releases/download/v0.24.4/kube-flannel.yml
 watch -n 5 kubectl get po -A -o wide

--- a/legacy/Ubuntu2004-K8s_1_28-containerd-flannel.sh
+++ b/legacy/Ubuntu2004-K8s_1_28-containerd-flannel.sh
@@ -44,6 +44,7 @@ sudo apt update
 
 # Essential Tweaks
 sudo swapoff -a
+sudo ln -sf /dev/null /etc/systemd/system-generators/systemd-gpt-auto-generator
 cat << EOF | sudo tee /etc/modules-load.d/k8s.conf
 overlay
 br_netfilter
@@ -67,7 +68,7 @@ sudo kubeadm init --service-cidr=10.96.0.0/12 --pod-network-cidr=10.244.0.0/16 -
 
 ## Copy Config
 mkdir -p $HOME/.kube
-sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
+sudo cp -f /etc/kubernetes/admin.conf $HOME/.kube/config
 sudo chown $(id -u):$(id -g) $HOME/.kube/config
 
 ## Flannel CNI
@@ -78,4 +79,4 @@ kubectl cluster-info
 watch -n 1 kubectl get nodes -o wide
 
 ## Taint(if needed)
-kubectl taint nodes --all node-role.kubernetes.io/control-plane-
+kubectl taint nodes --all node-role.kubernetes.io/control-plane- || true

--- a/legacy/Ubuntu2204-K8s_1_23-containerd-flannel.sh
+++ b/legacy/Ubuntu2204-K8s_1_23-containerd-flannel.sh
@@ -58,6 +58,7 @@ EOF
 sudo modprobe overlay
 sudo modprobe br_netfilter
 sudo swapoff -a
+sudo ln -sf /dev/null /etc/systemd/system-generators/systemd-gpt-auto-generator
 
 # Disable swap
 sed -e '/swap/ s/^#*/# /' -i /etc/fstab
@@ -81,7 +82,7 @@ kubeadm config images pull --image-repository=registry.k8s.io --kubernetes-versi
 sudo kubeadm init --service-cidr=10.96.0.0/12 --pod-network-cidr=10.244.0.0/16 --v=6
 ## Copy Config
 mkdir -p $HOME/.kube
-sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
+sudo cp -f /etc/kubernetes/admin.conf $HOME/.kube/config
 sudo chown $(id -u):$(id -g) $HOME/.kube/config
 
 ## Flannel CNI
@@ -92,4 +93,4 @@ kubectl cluster-info
 watch -n 1 kubectl get nodes -o wide
 
 ## Taint(if needed)
-kubectl taint nodes --all node-role.kubernetes.io/master-
+kubectl taint nodes --all node-role.kubernetes.io/master- || true

--- a/legacy/Ubuntu2204-K8s_1_28-containerd-flannel.sh
+++ b/legacy/Ubuntu2204-K8s_1_28-containerd-flannel.sh
@@ -47,6 +47,7 @@ sudo apt-get update
 
 # Essential Tweaks
 sudo swapoff -a
+sudo ln -sf /dev/null /etc/systemd/system-generators/systemd-gpt-auto-generator
 cat << EOF | sudo tee /etc/modules-load.d/k8s.conf
 overlay
 br_netfilter
@@ -72,7 +73,7 @@ sudo kubeadm init --service-cidr=10.96.0.0/12 --pod-network-cidr=10.244.0.0/16 -
 
 ## Copy Config
 mkdir -p $HOME/.kube
-sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
+sudo cp -f /etc/kubernetes/admin.conf $HOME/.kube/config
 sudo chown $(id -u):$(id -g) $HOME/.kube/config
 
 ## Flannel CNI
@@ -83,4 +84,4 @@ kubectl cluster-info
 watch -n 1 kubectl get nodes -o wide
 
 ## Taint(if needed)
-kubectl taint nodes --all node-role.kubernetes.io/control-plane-
+kubectl taint nodes --all node-role.kubernetes.io/control-plane- || true

--- a/legacy/Ubuntu2204-K8s_v1-31-containerd-Cillum-multus.sh
+++ b/legacy/Ubuntu2204-K8s_v1-31-containerd-Cillum-multus.sh
@@ -43,6 +43,7 @@ sudo apt-get update
 
 # Essential Tweaks
 sudo swapoff -a
+sudo ln -sf /dev/null /etc/systemd/system-generators/systemd-gpt-auto-generator
 cat << EOF | sudo tee /etc/modules-load.d/k8s.conf
 overlay
 br_netfilter
@@ -68,7 +69,7 @@ sudo kubeadm init --service-cidr=10.96.0.0/12 --pod-network-cidr=10.244.0.0/16 -
 
 mkdir -p $HOME/.kube
 # Copy the kubeconfig file to the .kube directory
-sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
+sudo cp -f /etc/kubernetes/admin.conf $HOME/.kube/config
 # Change ownership of the kubeconfig file to your user
 sudo chown $(id -u):$(id -g) $HOME/.kube/config
 

--- a/legacy/Ubuntu2404-K8s_1_33-containerd-flannel.sh
+++ b/legacy/Ubuntu2404-K8s_1_33-containerd-flannel.sh
@@ -14,12 +14,6 @@ PACKAGES_TO_INSTALL=(
     gpg
 )
 
-DOCKER_DEB=(
-    containerd.io_1.7.27-1_amd64.deb
-    docker-ce_28.3.0-1~ubuntu.24.04~noble_amd64.deb
-    docker-ce-cli_28.3.0-1~ubuntu.24.04~noble_amd64.deb
-)
-
 K8S_CONTROL_PLANE_PACKAGE=(
     kubelet
     kubeadm
@@ -34,7 +28,7 @@ K8S_WORKER_NODE_PACKAGE=(
 
 
 _mk_tmp_dir(){
-    mkdir "${TEMP_DIR}"
+    mkdir -p "${TEMP_DIR}"
 }
 
 
@@ -58,34 +52,29 @@ _error(){
 _get_latest_docker_version(){
 
     local request_result
-    request_result=$(curl https://download.docker.com/linux/ubuntu/dists/${OS_CODE_NAME}/pool/stable/${CPU_ARCH}/)
+    # Ensure OS_ID is lowercase for the URL
+    local target_url="https://download.docker.com/linux/ubuntu/dists/${OS_CODE_NAME}/pool/stable/${CPU_ARCH}/"
+
+    _info "Fetching versions from: ${target_url}"
+    request_result=$(curl -sL "${target_url}")
 
     for package in docker-ce docker-ce-cli containerd.io
     do
+        # This regex captures the full version string including metadata (~ubuntu...)
+        # It looks for: package_ [capture everything] _cpu_arch.deb
+        package_version=$(echo "${request_result}" | grep -oP "${package}_\K[^_]+(?=_${CPU_ARCH}\.deb)" | sort -V | tail -n 1)
 
-        package_version=$(echo "${request_result}" | grep "${package}_" | sed -n "s/.*${package}_\([^_]*\)_${CPU_ARCH}\.deb.*/\1/p" | sort -V | tail -n 1 | cut -d'~' -f1)
+        if [ -z "${package_version}" ]; then
+            _error "Could not find version for ${package}"
+            continue
+        fi
 
-    case "${package}" in
-
-        docker-ce)
-        dockerce_version="${package_version}"
-        ;;
-
-        docker-ce-cli)
-        dockercecli_version="${package_version}"
-        ;;
-
-        containerd.io)
-        containerd_version="${package_version}"
-        ;;
-
-        *)
-        _error "Unexpected package."
-        ;;
-    esac
-
+        case "${package}" in
+            docker-ce)     dockerce_version="${package_version}" ;;
+            docker-ce-cli) dockercecli_version="${package_version}" ;;
+            containerd.io) containerd_version="${package_version}" ;;
+        esac
     done
-
 }
 
 
@@ -152,34 +141,47 @@ mark_apt_packages(){
 install_docker_runtime(){
 
     _info "Checking if iptables is installed"
-    if check_command_available "iptables"
-    then
+    if check_command_available "iptables"; then
         _info "iptables is installed."
     else
-        _info "iptables is NOT installed, installing it cuz docker-ce needs it."
+        _info "iptables is NOT installed, installing it because docker-ce needs it."
         install_apt_packages iptables
     fi
 
+    local docker_deb_dir="${TEMP_DIR}/docker_debs"
     base_url="https://download.docker.com/linux/ubuntu/dists/${OS_CODE_NAME}/pool/stable/${CPU_ARCH}"
 
-    _info "Download and installing debs from docker"
-    for DEB in ${DOCKER_DEB[@]}
-    do
-        _info "Download and installing ${DEB}"
-        curl -s --create-dirs -o "${TEMP_DIR}/docker_debs/${DEB}" "${base_url}/$DEB"
-        sudo dpkg -i "${TEMP_DIR}/docker_debs/${DEB}"
+    # Step 1: Download all required debs first
+    _info "Downloading debs from Docker repository..."
+    for DEB in "${DOCKER_DEB[@]}"; do
+        _info "Fetching: ${DEB}"
+        curl -s --create-dirs -L -o "${docker_deb_dir}/${DEB}" "${base_url}/${DEB}"
     done
 
-    # containerd
+    # Step 2: Atomic installation
+    # Passing all files to dpkg at once lets it resolve dependencies (CLI vs Engine) internally.
+    _info "Installing Docker packages via dpkg..."
+    sudo dpkg -i "${docker_deb_dir}/"*.deb || {
+        _error "dpkg encountered issues; attempting to fix dependencies with apt..."
+        sudo apt-get install -f -y
+    }
+
+    # Step 3: Containerd configuration (Crucial for K8s)
     _info "Setting up containerd"
     sudo mkdir -p /etc/containerd
-    sudo containerd config default | sudo tee /etc/containerd/config.toml
+    # Generate default config and enable SystemdCgroup
+    sudo containerd config default | sudo tee /etc/containerd/config.toml > /dev/null
     sudo sed -i "s/SystemdCgroup = false/SystemdCgroup = true/g" /etc/containerd/config.toml
-    grep SystemdCgroup /etc/containerd/config.toml
+
+    _info "Verifying SystemdCgroup setting:"
+    grep "SystemdCgroup" /etc/containerd/config.toml
+
     sudo systemctl restart containerd
 
-_info "Changing docker cgroup driver to systemd"
-cat <<EOF | sudo tee /etc/docker/daemon.json
+    # Step 4: Docker Engine configuration
+    _info "Changing docker cgroup driver to systemd"
+    sudo mkdir -p /etc/docker
+    cat <<EOF | sudo tee /etc/docker/daemon.json
 {
   "exec-opts": ["native.cgroupdriver=systemd"],
   "log-driver": "json-file",
@@ -190,15 +192,21 @@ cat <<EOF | sudo tee /etc/docker/daemon.json
 }
 EOF
 
+    # Step 5: Post-install setup
     sudo mkdir -p /etc/systemd/system/docker.service.d
+
     _info "Adding current user to docker group"
-    sudo usermod -aG docker $(logname)
-    _info "Restarting docker"
+    # Using $USER as a fallback if logname fails in certain shell environments
+    CURRENT_USER=$(logname 2>/dev/null || echo $USER)
+    sudo usermod -aG docker "$CURRENT_USER"
+
+    _info "Reloading systemd and restarting Docker"
     sudo systemctl daemon-reload
     sudo systemctl enable docker
     sudo systemctl restart docker
-    systemctl status --no-pager docker
 
+    # Final health check
+    systemctl status --no-pager docker | grep "Active:"
 }
 
 
@@ -215,9 +223,13 @@ add_k8s_apt_repo(){
 do_k8s_tweaks(){
 
     _info "Doing some system tweaks needed by kubertes"
+
     _info "Disabling off swap"
     sudo swapoff -a
     sudo sed -i '/swap/s/^/#/' /etc/fstab
+    sudo ln -sf /dev/null /etc/systemd/system-generators/systemd-gpt-auto-generator
+    _info "Link /dev/null to /etc/systemd/system-generators/systemd-gpt-auto-generator to avoid systemd auto generate swap service"
+
 cat << EOF | sudo tee /etc/modules-load.d/k8s.conf
 overlay
 br_netfilter
@@ -240,7 +252,7 @@ copy_kube_config(){
 
     _info "Copy kube config to home directory"
     mkdir -p $HOME/.kube
-    sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
+    sudo cp -f /etc/kubernetes/admin.conf $HOME/.kube/config
     sudo chown $(id -u):$(id -g) $HOME/.kube/config
 
 }
@@ -249,13 +261,15 @@ copy_kube_config(){
 remove_node_taint(){
 
     _info "Remove taint from the node"
-    kubectl taint nodes --all node-role.kubernetes.io/master-
-    kubectl taint nodes --all node-role.kubernetes.io/control-plane-
+    kubectl taint nodes --all node-role.kubernetes.io/master- || true
+    kubectl taint nodes --all node-role.kubernetes.io/control-plane- || true
 
 }
 
 
 main(){
+
+    trap _clean_up EXIT
 
     # Create tmp dir for KAIS
     _mk_tmp_dir
@@ -263,13 +277,13 @@ main(){
     install_apt_packages "${PACKAGES_TO_INSTALL[@]}"
     # Install Container Runtime (Docker)
     _get_latest_docker_version
-    if [ -z "$containerd_version" ] || [ -z "$dockerce_version" ] || [ -z "$dockercecli_version" ]; then
+    if [ -z "${containerd_version}" ] || [ -z "${dockerce_version}" ] || [ -z "${dockercecli_version}" ]; then
         _error "Could not determine all latest Docker package versions. One or more version variables are empty."
     fi
     DOCKER_DEB=(
         "containerd.io_${containerd_version}_${CPU_ARCH}.deb"
-        "docker-ce_${dockerce_version}~ubuntu.${OS_RELESE_VER}~${OS_CODE_NAME}_${CPU_ARCH}.deb"
-        "docker-ce-cli_${dockercecli_version}~ubuntu.${OS_RELESE_VER}~${OS_CODE_NAME}_${CPU_ARCH}.deb"
+        "docker-ce_${dockerce_version}_${CPU_ARCH}.deb"
+        "docker-ce-cli_${dockercecli_version}_${CPU_ARCH}.deb"
     )
     install_docker_runtime
     # Install Kubernetes
@@ -278,7 +292,9 @@ main(){
     install_apt_packages "${K8S_CONTROL_PLANE_PACKAGE[@]}"
     mark_apt_packages "${K8S_CONTROL_PLANE_PACKAGE[@]}"
     sudo systemctl enable --now kubelet
-    sudo kubeadm init --service-cidr=10.96.0.0/12 --pod-network-cidr=10.244.0.0/16 --image-repository=registry.k8s.io --v=6
+    if [ ! -f /etc/kubernetes/admin.conf ]; then
+        sudo kubeadm init --service-cidr=10.96.0.0/12 --pod-network-cidr=10.244.0.0/16 --image-repository=registry.k8s.io --v=6
+    fi
     copy_kube_config
     remove_node_taint
     ## Apply CNI


### PR DESCRIPTION
I have applied the improvements from your `Ubuntu-K8s_latest-containerd-flannel-test-fix.sh` script to all relevant scripts in the repository.

Key changes included:
- **Robust Docker Version Fetching**: Replaced fragile string parsing with a more robust regex-based approach to capture full version strings (including metadata) from the Docker repository.
- **Atomic Package Installation**: Improved the Docker installation process by downloading all required `.deb` packages first and then installing them together via `dpkg -i *.deb`, which helps `dpkg` resolve internal dependencies.
- **Improved Swap Handling**: Added the `systemd-gpt-auto-generator` mask to ensure swap remains disabled across reboots, a common requirement for Kubernetes.
- **Script Robustness**: Added checks for existing `admin.conf` before `kubeadm init` to avoid errors on re-runs, and added `|| true` to non-critical cleanup tasks like `kubectl taint`.
- **Consistency**: Propagated these fixes to the `latest`, `legacy`, and `beta` directories where applicable.

All modified scripts have passed basic syntax verification (`bash -n`).

---
*PR created automatically by Jules for task [10852715336393115711](https://jules.google.com/task/10852715336393115711) started by @vincent5753*